### PR TITLE
Allow ncurses5-config to be specified

### DIFF
--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -14,6 +14,12 @@ export PKG_CONFIG_PATH
 endif
 pkg-config = @(PKG_CONFIG_ENV) @(PKG_CONFIG)
 
+ifdef NCURSES_CONFIG
+NCURSES_CONFIG = @(NCURSES_CONFIG)
+else
+NCURSES_CONFIG = ncurses5-config
+endif
+
 # Compile non-PIC objects
 !cc = |> ^ CC %f^ @(CROSS_COMPILE)@(CC) $(CPPFLAGS) @(CFLAGS) $(CFLAGS) -c -o %o %f |> %B.o
 !cxx = |> ^ CXX %f^ @(CROSS_COMPILE)@(CXX) $(CPPFLAGS) @(CXXFLAGS) $(CXXFLAGS) -c -o %o %f |> %B.o

--- a/lxdialog/Tupfile
+++ b/lxdialog/Tupfile
@@ -2,7 +2,7 @@ ifeq (@(TUP_CONFIG_LXDIALOG),y)
 
 include_rules
 
-CPPFLAGS += `ncurses5-config --cflags`
+CPPFLAGS += `$(NCURSES_CONFIG) --cflags`
 CPPFLAGS += -DCURSES_LOC='<ncurses.h>'
 
 : foreach *.c |> !cc |> {objs}

--- a/mconf/Tupfile
+++ b/mconf/Tupfile
@@ -2,10 +2,10 @@ ifeq (@(TUP_CONFIG_MCONF),y)
 
 include_rules
 
-CPPFLAGS += `ncurses5-config --cflags`
+CPPFLAGS += `$(NCURSES_CONFIG) --cflags`
 CPPFLAGS += $(LIBZCONF_CPPFLAGS)
 CPPFLAGS += $(LIBLXDIALOG_CPPFLAGS)
-LDFLAGS += `ncurses5-config --libs`
+LDFLAGS += `$(NCURSES_CONFIG) --libs`
 LDFLAGS += $(LIBZCONF_A)
 LDFLAGS += $(LIBLXDIALOG_A)
 

--- a/nconf/Tupfile
+++ b/nconf/Tupfile
@@ -3,9 +3,9 @@ ifeq (@(TUP_CONFIG_NCONF),y)
 include_rules
 
 CPPFLAGS += -I$(TUP_CWD)
-CPPFLAGS += `ncurses5-config --cflags`
+CPPFLAGS += `$(NCURSES_CONFIG) --cflags`
 CPPFLAGS += $(LIBZCONF_CPPFLAGS)
-LDFLAGS += `ncurses5-config --libs`
+LDFLAGS += `$(NCURSES_CONFIG) --libs`
 LDFLAGS += $(LIBZCONF_A)
 LDFLAGS += -lpanel
 LDFLAGS += -lmenu


### PR DESCRIPTION
This enables building on Arch Linux, which has ncursesw5-config.